### PR TITLE
Refactoring status values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -955,9 +955,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1636,9 +1636,9 @@
       }
     },
     "semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "start": "npm run dev",
+    "start": "npm run tauri:dev",
     "tauri": "tauri",
     "tauri:dev": "tauri dev"
   },

--- a/src-tauri/src/data_model.rs
+++ b/src-tauri/src/data_model.rs
@@ -5,7 +5,6 @@ use serde::{Serialize, Deserialize};
 pub struct Farm {
     pub id: usize,
     pub name: String,
-    // pub measurements: Vec<Measurement>,
     pub status: Status,
     pub timestamp: usize,
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,64 +1,9 @@
 <script setup lang="ts">
 import { invoke } from '@tauri-apps/api/tauri';
 import { onMounted, reactive } from 'vue';
+import { toBackendFarmObject, BackendFarmObject, FarmListItem } from './farms';
+import { RED, YELLOW, toStatusObject } from './status';
 import FarmList from './components/FarmList.vue';
-
-const RED = Symbol('RED');
-const YELLOW = Symbol('YELLOW');
-const GREEN = Symbol('GREEN');
-const DEFAULT_STATUS_SYMBOL = RED;
-
-interface ColorMap {
-  [color: symbol]: { title: string, emoji: string }
-}
-const colorMap: ColorMap = {
-  [RED]: {
-    emoji: '🔴',
-    title: 'Red',
-  },
-  [YELLOW]: {
-    emoji: '🟡',
-    title: 'Yellow',
-  },
-  [GREEN]: {
-    emoji: '🟢',
-    title: 'Green',
-  },
-};
-interface StatusObject {
-  symbol: symbol,
-  emoji: string,
-  title: string,
-}
-const fromSymbol = (symbol: symbol): StatusObject => {
-  if (symbol in colorMap) return {
-    emoji: colorMap[symbol].emoji,
-    symbol,
-    title: colorMap[symbol].title,
-  };
-  return fromSymbol(DEFAULT_STATUS_SYMBOL);
-};
-const defaultStatus: StatusObject = fromSymbol(DEFAULT_STATUS_SYMBOL);
-const colors: StatusObject[] = Object.getOwnPropertySymbols(colorMap).map(fromSymbol);
-const fromAttr = (attr?: string): StatusObject =>
-  colors.find(c => attr === c.title || attr === c.emoji) || defaultStatus;
-const toStatusObject = (status?: symbol|string): StatusObject =>
-  typeof status === 'symbol' ? fromSymbol(status) : fromAttr(status);
-
-interface BackendFarmObject {
-  id: number,
-  name: string,
-  status: string,
-  timestamp: number,
-}
-interface FarmListItem {
-  id: number,
-  name: string,
-  status: StatusObject,
-  timestamp: number,
-}
-const toBackendFarmObject = (f: FarmListItem): BackendFarmObject =>
-  ({ ...f, status: f.status.title });
 
 const farms: FarmListItem[] = reactive([]);
 const defaultFarms: FarmListItem[] = [

--- a/src/components/FarmList.vue
+++ b/src/components/FarmList.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
-defineProps<{farms: Array<{
-  id: number,
-  name: string,
-  status: {
-    emoji: string,
-    symbol: symbol,
-    title: string,
-  },
-  timestamp: number,
-}>}>()
+import { FarmListItem } from '../farms';
+
+defineProps<{ farms: FarmListItem[] }>()
 </script>
 
 <template>

--- a/src/components/FarmList.vue
+++ b/src/components/FarmList.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
-defineProps<{ farms: Array<{ name: string, status: string, timestamp: number }> }>()
+defineProps<{farms: Array<{
+  id: number,
+  name: string,
+  status: {
+    emoji: string,
+    symbol: symbol,
+    title: string,
+  },
+  timestamp: number,
+}>}>()
 </script>
 
 <template>
@@ -8,7 +17,7 @@ defineProps<{ farms: Array<{ name: string, status: string, timestamp: number }> 
     <li v-for="(farm, i) in farms" :key="`farm-${i}`" class="farm-total">
       <div class="primary-info">
         <span class="status">
-          {{ farm.status }}
+          {{ farm.status.emoji }}
         </span>
         <span class="name">
           {{ farm.name }}

--- a/src/farms.ts
+++ b/src/farms.ts
@@ -1,0 +1,17 @@
+import { StatusObject } from "./status";
+
+export interface BackendFarmObject {
+  id: number,
+  name: string,
+  status: string,
+  timestamp: number,
+}
+export interface FarmListItem {
+  id: number,
+  name: string,
+  status: StatusObject,
+  timestamp: number,
+}
+
+export const toBackendFarmObject = (f: FarmListItem): BackendFarmObject =>
+  ({ ...f, status: f.status.title });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import { createApp } from 'vue';
-// import './style.css';
 import App from './App.vue';
 
 createApp(App).mount('#app')

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,45 @@
+export const RED = Symbol('RED');
+export const YELLOW = Symbol('YELLOW');
+export const GREEN = Symbol('GREEN');
+export const DEFAULT_STATUS_SYMBOL = RED;
+
+export interface StatusObject {
+  symbol: symbol,
+  emoji: string,
+  title: string,
+}
+
+interface ColorMap {
+  [color: symbol]: { title: string, emoji: string }
+}
+const colorMap: ColorMap = {
+  [RED]: {
+    emoji: '🔴',
+    title: 'Red',
+  },
+  [YELLOW]: {
+    emoji: '🟡',
+    title: 'Yellow',
+  },
+  [GREEN]: {
+    emoji: '🟢',
+    title: 'Green',
+  },
+};
+
+const fromSymbol = (symbol: symbol): StatusObject => {
+  if (symbol in colorMap) return {
+    emoji: colorMap[symbol].emoji,
+    symbol,
+    title: colorMap[symbol].title,
+  };
+  return fromSymbol(DEFAULT_STATUS_SYMBOL);
+};
+
+export const colors: StatusObject[] = Object.getOwnPropertySymbols(colorMap).map(fromSymbol);
+
+const fromAttr = (attr?: string): StatusObject => colors.find(c =>
+  attr === c.title || attr === c.emoji) || fromSymbol(DEFAULT_STATUS_SYMBOL);
+
+export const toStatusObject = (status?: symbol|string): StatusObject =>
+  typeof status === 'symbol' ? fromSymbol(status) : fromAttr(status);


### PR DESCRIPTION
I refactored and tidied up a bit before getting back to the main alpha.1 milestone issues.

The main thing is how the status value was being converted from the backend string value (eg, `"Green"`) to an emoji for the farm list (eg, `"🟢"`). I added a couple hacks and sloppy naming conventions in 9327343, and that was probably fine b/c we know we want to eventually use some kind of numeric code for the primary status value, possibly for #6, but it got me thinking more about the domain model.

I think there is a valid case to make that the color codes are in one sense "original" data, insofar as they can represent a verbal, qualitative assessment, but in another sense they are meant to display the status as a computed value, derived from the last known assessment value and the time that has elapsed since it was recorded, as laid out in #6.

To my mind, it makes sense to call the original qualitative assessment value a __triage__ value, which can be stored as an integer,[^1] while the term __status__ is reserved for the computed or derived value at any given moment and can be a float  or a string or whatever form makes sense in the given context. Both can be represented by the same color coding or other indicators in the UI, and it may also be helpful to store both in some capacity, but a status value can be treated as ephemeral state, whereas a triage value is original data that should be preserved. This distinction should become more apparent once we begin deriving the status from not just qualitative but quantitative assessments, as well as aggregations of both.

[^1]: I haven't made up my mind at all about this, but possibly the set of `[-1, 0, 1, 2]`, where `0` is red, `1` is yellow and `2` (or anything higher than 1) is green; `-1` is for an inactive or ignored status, something we might represent with a neutral color.